### PR TITLE
Remove brackets around ${APP_DIR} VOLUME definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir ${APP_DIR} \
 	&& chown -R nginx:nginx ${APP_DIR} \
 	&& chmod 777 /run/ -R \
 	&& chmod 777 /root/ -R
-VOLUME [${APP_DIR}]
+VOLUME ${APP_DIR}
 WORKDIR ${APP_DIR}
 
 # expose web server port


### PR DESCRIPTION
This does not play well with windows, at least, where it creates a structure like this 

+ [
 | + APP]